### PR TITLE
add rails 4.2 support. Access transaction through `@transaction_manager`

### DIFF
--- a/gemfiles/42.gemfile
+++ b/gemfiles/42.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec :path=>"../"
+
+gem "activerecord", "~> 4.2.0.beta1"
+gem "rails-observers"

--- a/gemfiles/42.gemfile.lock
+++ b/gemfiles/42.gemfile.lock
@@ -1,0 +1,62 @@
+PATH
+  remote: ../
+  specs:
+    test_after_commit (0.2.5)
+      activerecord (>= 3.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.2.0.beta1)
+      activesupport (= 4.2.0.beta1)
+      builder (~> 3.1)
+    activerecord (4.2.0.beta1)
+      activemodel (= 4.2.0.beta1)
+      activesupport (= 4.2.0.beta1)
+      arel (>= 6.0.0.beta1, < 6.1)
+    activesupport (4.2.0.beta1)
+      i18n (>= 0.7.0.beta1, < 0.8)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    arel (6.0.0.beta1)
+    builder (3.2.2)
+    bump (0.5.0)
+    diff-lcs (1.2.5)
+    i18n (0.7.0.beta1)
+    json (1.8.1)
+    minitest (5.4.0)
+    rails-observers (0.1.2)
+      activemodel (~> 4.0)
+    rake (10.3.2)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.4)
+    sqlite3 (1.3.9)
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    wwtd (0.5.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord (~> 4.2.0.beta1)
+  bump
+  rails-observers
+  rake
+  rspec
+  sqlite3
+  test_after_commit!
+  wwtd

--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -28,9 +28,10 @@ ActiveRecord::ConnectionAdapters::DatabaseStatements.class_eval do
     if ActiveRecord::VERSION::MAJOR == 3
       commit_transaction_records(false)
     else
-      @transaction.commit_records
-      @transaction.records.clear # prevent duplicate .commit!
-      @transaction.instance_variable_get(:@state).set_state(nil)
+      transaction = @transaction || @transaction_manager.current_transaction
+      transaction.commit_records
+      transaction.records.clear # prevent duplicate .commit!
+      transaction.instance_variable_get(:@state).set_state(nil)
     end
   end
 


### PR DESCRIPTION
In rails 4.2.beta1, `@transaction` is not defined. Instead the transaction can be accessed through `@transaction_manager.current_transaction`.
