### PR TITLE
Support for raise_in_transactional_callbacks in Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ gemfile:
   - gemfiles/32.gemfile
   - gemfiles/40.gemfile
   - gemfiles/41.gemfile
+  - gemfiles/42.gemfile
 rvm:
   - ree
   - 1.9.3
@@ -18,4 +19,6 @@ matrix:
       gemfile: gemfiles/40.gemfile
     - rvm: ree
       gemfile: gemfiles/41.gemfile
+    - rvm: ree
+      gemfile: gemfiles/42.gemfile
 script: bundle exec rake spec

--- a/gemfiles/32.gemfile.lock
+++ b/gemfiles/32.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    test_after_commit (0.2.5)
+    test_after_commit (0.2.7)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/40.gemfile.lock
+++ b/gemfiles/40.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    test_after_commit (0.2.5)
+    test_after_commit (0.2.7)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/41.gemfile.lock
+++ b/gemfiles/41.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    test_after_commit (0.2.5)
+    test_after_commit (0.2.7)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/42.gemfile.lock
+++ b/gemfiles/42.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    test_after_commit (0.2.5)
+    test_after_commit (0.2.7)
       activerecord (>= 3.2)
 
 GEM


### PR DESCRIPTION
When config.active_record.raise_in_transactional_callbacks is enabled (causing
errors raised in after_commit to be raised rather than swallowed), no
subsequent after_commit callbacks were being called.
