### PR TITLE
fix nested after_commit callbacks

### DIFF
--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -9,17 +9,20 @@ ActiveRecord::ConnectionAdapters::DatabaseStatements.class_eval do
     transaction_without_transactional_fixtures(*args) do
       begin
         @test_open_transactions += 1
+        if ActiveRecord::VERSION::MAJOR == 3
+          @_current_transaction_records.push([]) if @_current_transaction_records.empty?
+        end
         result = yield
       rescue Exception => e
         rolled_back = true
         raise e
       ensure
         begin
-          if @test_open_transactions == 1 && !rolled_back
+          @test_open_transactions -= 1
+          if @test_open_transactions == 0 && !rolled_back
             test_commit_records
           end
         ensure
-          @test_open_transactions -= 1
           result
         end
       end
@@ -29,44 +32,19 @@ ActiveRecord::ConnectionAdapters::DatabaseStatements.class_eval do
 
   def test_commit_records
     if ActiveRecord::VERSION::MAJOR == 3
-      commit_transaction_records(false)
+      commit_transaction_records
     else
-      transaction = @transaction || @transaction_manager.current_transaction
-      begin
-        transaction.commit_records
-      ensure
-        transaction.records.clear # prevent duplicate .commit!
-        transaction.instance_variable_get(:@state).set_state(nil)
-      end
-    end
-  end
-
-  if ActiveRecord::VERSION::MAJOR == 3
-    # The @_current_transaction_records is a stack of arrays, each one
-    # containing the records associated with the corresponding transaction
-    # in the transaction stack. This is used by the
-    # `rollback_transaction_records` method (to only send a rollback hook to
-    # models attached to the transaction being rolled back) but is usually
-    # ignored by the `commit_transaction_records` method. Here we
-    # monkey-patch it to temporarily replace the array with only the records
-    # for the top-of-stack transaction, so the real
-    # `commit_transaction_records` method only sends callbacks to those.
-    #
-    def commit_transaction_records_with_transactional_fixtures(commit = true)
-      return commit_transaction_records_without_transactional_fixtures if commit
-
-      preserving_current_transaction_records do
-        @_current_transaction_records = @_current_transaction_records.pop || []
-        commit_transaction_records_without_transactional_fixtures
-      end
-    end
-    alias_method_chain :commit_transaction_records, :transactional_fixtures
-
-    def preserving_current_transaction_records
-      old_current_transaction_records = @_current_transaction_records.dup
-      yield
-    ensure
-      @_current_transaction_records = old_current_transaction_records
+      # To avoid an infinite loop, we need to copy the transaction locally, and clear out
+      # `records` on the copy that stays in the AR stack. Otherwise new
+      # transactions inside a commit callback will cause an infinite loop.
+      #
+      # This is because we're re-using the transaction on the stack, before
+      # it's been popped off and re-created by the AR code.
+      original = @transaction || @transaction_manager.current_transaction
+      transaction = original.dup
+      transaction.instance_variable_set(:@records, transaction.records.dup) # deep clone of records array
+      original.records.clear                                                # so that this clear doesn't clear out both copies
+      transaction.commit_records
     end
   end
 end

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -100,12 +100,14 @@ end
 
 class CarObserver < ActiveRecord::Observer
   cattr_accessor :recording
+  cattr_accessor :callback
 
   [:after_commit, :after_rollback].each do |action|
     define_method action do |record|
       return unless recording
       Car.called << "observed_#{action}".to_sym
       Untracked.create!
+      callback.call() if callback
     end
   end
 end


### PR DESCRIPTION
Hey, hopefully this all checks out. All the tests pass, and I pored through the AR 3.2 and 4.1 code to make sure I understand all the angles, but this is really complex code, and I worry that I might have inadvertently broken something that doesn't have a test.

For what it's worth, with this change we have a very large rails 3.2 test suite that can now pass using this gem, rather than some silly AR monkey patching it did directly before.
