### PR TITLE
Fix behavior with Rails from 4-2-stable

### DIFF
--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -54,7 +54,12 @@ if ActiveRecord::VERSION::MAJOR >= 4
   ActiveRecord::Base.class_eval do
     alias_method :sync_with_transaction_state_with_state, :sync_with_transaction_state
     def sync_with_transaction_state
-      @reflects_state[0] = true
+      if @reflects_state
+        @reflects_state[0] = true
+      else
+        @reflects_state = [true]
+      end
+
       sync_with_transaction_state_with_state
     end
   end


### PR DESCRIPTION
The commit rails/rails@9ddb955 introduces a change with `@reflects_state` ivar, it's not always set now, and `@reflects_state[0] = true` raises NoMethodError in this case. 

I added simplest workaround.