### PR TITLE
Add default behavior configuration and ability to customize with blocks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    sqlite3 (1.3.8)
+    sqlite3 (1.3.11)
     thread_safe (0.1.3)
       atomic
     tzinfo (0.3.38)
@@ -58,3 +58,6 @@ DEPENDENCIES
   sqlite3
   test_after_commit!
   wwtd
+
+BUNDLED WITH
+   1.10.5

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,8 @@ it "sets $foo on commit" do
   $foo.should == 1
 end
 ```
-By default, all after commits will fire throughout the test suite. However, you may wish to choose when to run them or not to. For example, when adding this to an existing test suite.
+
+### Temporary disable after commit hooks
 
 In your test_helper, you can specify the default
 

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,25 @@ it "sets $foo on commit" do
   $foo.should == 1
 end
 ```
+By default, all after commits will fire throughout the test suite. However, you may wish to choose when to run them or not to. For example, when adding this to an existing test suite.
+
+In your test_helper, you can specify the default
+
+```
+TestAfterCommit.enabled_by_default = true
+```
+
+Then use blocks in your tests to change the behavior:
+
+```
+TestAfterCommit.with_commits do
+  my_tests
+end
+
+TestAfterCommit.without_commits do
+  my_tests
+end
+```
 
 TIPS
 ====

--- a/Readme.md
+++ b/Readme.md
@@ -36,17 +36,17 @@ By default, all after commits will fire throughout the test suite. However, you 
 In your test_helper, you can specify the default
 
 ```
-TestAfterCommit.enabled_by_default = true
+TestAfterCommit.enabled = true
 ```
 
 Then use blocks in your tests to change the behavior:
 
 ```
-TestAfterCommit.with_commits do
+TestAfterCommit.with_commits(true) do
   my_tests
 end
 
-TestAfterCommit.without_commits do
+TestAfterCommit.with_commits(false) do
   my_tests
 end
 ```

--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -1,6 +1,23 @@
 require 'test_after_commit/version'
 
 module TestAfterCommit
+  @enabled_by_default = true
+  @commits_on = true
+
+  def self.with_commits(&block)
+    @commits_on = true
+    yield(block)
+    @commits_on = @enabled_by_default
+  end
+
+  def self.enabled_by_default=(val)
+    @enabled_by_default = val
+    @commits_on = val
+  end
+
+  def self.commits_on
+    @commits_on
+  end
 end
 
 ActiveRecord::ConnectionAdapters::DatabaseStatements.class_eval do
@@ -19,7 +36,7 @@ ActiveRecord::ConnectionAdapters::DatabaseStatements.class_eval do
       ensure
         begin
           @test_open_transactions -= 1
-          if @test_open_transactions == 0 && !rolled_back
+          if TestAfterCommit.commits_on && @test_open_transactions == 0 && !rolled_back
             test_commit_records
           end
         ensure

--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -5,7 +5,7 @@ module TestAfterCommit
   class << self
     attr_accessor :enabled
 
-    def with_commits(value)
+    def with_commits(value = true)
       old = enabled
       self.enabled = value
       yield

--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -7,16 +7,26 @@ module TestAfterCommit
   def self.with_commits(&block)
     @commits_on = true
     yield(block)
-    @commits_on = @enabled_by_default
+    reset
+  end
+
+  def self.without_commits(&block)
+    @commits_on = false
+    yield(block)
+    reset
   end
 
   def self.enabled_by_default=(val)
     @enabled_by_default = val
-    @commits_on = val
+    reset
   end
 
   def self.commits_on
     @commits_on
+  end
+
+  def self.reset
+    @commits_on = @enabled_by_default
   end
 end
 

--- a/spec/test_after_commit_spec.rb
+++ b/spec/test_after_commit_spec.rb
@@ -192,6 +192,13 @@ describe TestAfterCommit do
       end
     end
 
+    it "defaults to with commits" do
+      TestAfterCommit.with_commits do
+        Car.create
+        Car.called.should == [:create, :always]
+      end
+    end
+
     it "does not fire with without commits" do
       TestAfterCommit.with_commits(false) do
         Car.create

--- a/spec/test_after_commit_spec.rb
+++ b/spec/test_after_commit_spec.rb
@@ -14,6 +14,10 @@ describe TestAfterCommit do
     Car.called.clear
   end
 
+  after do
+    TestAfterCommit.enabled = true
+  end
+
   it "has a VERSION" do
     TestAfterCommit::VERSION.should =~ /^[\.\da-z]+$/
   end
@@ -175,23 +179,21 @@ describe TestAfterCommit do
 
   context "block behavior" do
     it "does not fire if turned off" do
-      TestAfterCommit.enabled_by_default = false # this would ideally be called in test_helper
+      TestAfterCommit.enabled = false
       Car.create
       Car.called.should == []
-      TestAfterCommit.enabled_by_default = true # set back for the rest of the tests to pass
     end
 
-    it "always fires with with_commit" do
-      TestAfterCommit.enabled_by_default = false
-      TestAfterCommit.with_commits do
+    it "always fires with when enabled by a block" do
+      TestAfterCommit.enabled = false
+      TestAfterCommit.with_commits(true) do
         Car.create
         Car.called.should == [:create, :always]
       end
-      TestAfterCommit.enabled_by_default = true
     end
 
-    it "does not fire with without_commits" do
-      TestAfterCommit.without_commits do
+    it "does not fire with without commits" do
+      TestAfterCommit.with_commits(false) do
         Car.create
         Car.called.should == []
       end

--- a/spec/test_after_commit_spec.rb
+++ b/spec/test_after_commit_spec.rb
@@ -23,13 +23,6 @@ describe TestAfterCommit do
     Car.called.should == [:create, :always]
   end
 
-  it "does not fire if turned off" do
-    TestAfterCommit.enabled_by_default = false # this would ideally be called in test_helper
-    Car.create
-    Car.called.should == []
-    TestAfterCommit.enabled_by_default = true # set back for the rest of the tests to pass
-  end
-
   it "fires on update" do
     car = Car.create
     Car.called.clear
@@ -176,6 +169,31 @@ describe TestAfterCommit do
         open_txn.should == 0
       ensure
         CarObserver.callback = nil
+      end
+    end
+  end
+
+  context "block behavior" do
+    it "does not fire if turned off" do
+      TestAfterCommit.enabled_by_default = false # this would ideally be called in test_helper
+      Car.create
+      Car.called.should == []
+      TestAfterCommit.enabled_by_default = true # set back for the rest of the tests to pass
+    end
+
+    it "always fires with with_commit" do
+      TestAfterCommit.enabled_by_default = false
+      TestAfterCommit.with_commits do
+        Car.create
+        Car.called.should == [:create, :always]
+      end
+      TestAfterCommit.enabled_by_default = true
+    end
+
+    it "does not fire with without_commits" do
+      TestAfterCommit.without_commits do
+        Car.create
+        Car.called.should == []
       end
     end
   end

--- a/spec/test_after_commit_spec.rb
+++ b/spec/test_after_commit_spec.rb
@@ -23,6 +23,13 @@ describe TestAfterCommit do
     Car.called.should == [:create, :always]
   end
 
+  it "does not fire if turned off" do
+    TestAfterCommit.enabled_by_default = false # this would ideally be called in test_helper
+    Car.create
+    Car.called.should == []
+    TestAfterCommit.enabled_by_default = true # set back for the rest of the tests to pass
+  end
+
   it "fires on update" do
     car = Car.create
     Car.called.clear
@@ -102,7 +109,7 @@ describe TestAfterCommit do
     car.do_after_create_save = true
     car.save!
 
-    expected = if rails4?
+    expected = if rails42?
       [:save_once, :create, :always, :save_once, :always]
     else
       [:save_once, :create, :always, :save_once, :create, :always]


### PR DESCRIPTION
I needed to add this to an existing test suite with over 3000 assertions. Simply adding all after commits firing broke a large number of assertions (particularly because of some serialization caching where cache was built in after commits)

Anyway, I added the ability to essentially toggle the behavior on and off when needed. See my edits to the Readme.md.