### PR TITLE
Remove deprecated syntax

### DIFF
--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -2,11 +2,11 @@ require 'test_after_commit/version'
 
 if ActiveRecord::VERSION::MAJOR >= 4
   require 'test_after_commit/with_transaction_state'
-  ActiveRecord::Base.__send__(:include, TestAfterCommit::WithTransactionState)
+  ActiveRecord::Base.__send__(:prepend, TestAfterCommit::WithTransactionState)
 end
 
 require 'test_after_commit/database_statements'
-ActiveRecord::ConnectionAdapters::AbstractAdapter.__send__(:include, TestAfterCommit::DatabaseStatements)
+ActiveRecord::ConnectionAdapters::AbstractAdapter.__send__(:prepend, TestAfterCommit::DatabaseStatements)
 
 module TestAfterCommit
   @enabled = true

--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -2,11 +2,11 @@ require 'test_after_commit/version'
 
 if ActiveRecord::VERSION::MAJOR >= 4
   require 'test_after_commit/with_transaction_state'
-  ActiveRecord::Base.__send__(:prepend, TestAfterCommit::WithTransactionState)
+  ActiveRecord::Base.prepend(TestAfterCommit::WithTransactionState)
 end
 
 require 'test_after_commit/database_statements'
-ActiveRecord::ConnectionAdapters::AbstractAdapter.__send__(:prepend, TestAfterCommit::DatabaseStatements)
+ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend(TestAfterCommit::DatabaseStatements)
 
 module TestAfterCommit
   @enabled = true

--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -1,5 +1,13 @@
 require 'test_after_commit/version'
 
+if ActiveRecord::VERSION::MAJOR >= 4
+  require 'test_after_commit/with_transaction_state'
+  ActiveRecord::Base.__send__(:include, TestAfterCommit::WithTransactionState)
+end
+
+require 'test_after_commit/database_statements'
+ActiveRecord::ConnectionAdapters::AbstractAdapter.__send__(:include, TestAfterCommit::DatabaseStatements)
+
 module TestAfterCommit
   @enabled = true
   class << self
@@ -11,64 +19,6 @@ module TestAfterCommit
       yield
     ensure
       self.enabled = old
-    end
-  end
-end
-
-ActiveRecord::ConnectionAdapters::DatabaseStatements.class_eval do
-  def transaction_with_transactional_fixtures(*args)
-    @test_open_transactions ||= 0
-    transaction_without_transactional_fixtures(*args) do
-      begin
-        @test_open_transactions += 1
-        if ActiveRecord::VERSION::MAJOR == 3
-          @_current_transaction_records.push([]) if @_current_transaction_records.empty?
-        end
-        result = yield
-      rescue Exception => e
-        rolled_back = true
-        raise e
-      ensure
-        begin
-          @test_open_transactions -= 1
-          if TestAfterCommit.enabled && @test_open_transactions == 0 && !rolled_back
-            test_commit_records
-          end
-        ensure
-          result
-        end
-      end
-    end
-  end
-  alias_method_chain :transaction, :transactional_fixtures
-
-  def test_commit_records
-    if ActiveRecord::VERSION::MAJOR == 3
-      commit_transaction_records
-    else
-      # To avoid an infinite loop, we need to copy the transaction locally, and clear out
-      # `records` on the copy that stays in the AR stack. Otherwise new
-      # transactions inside a commit callback will cause an infinite loop.
-      #
-      # This is because we're re-using the transaction on the stack, before
-      # it's been popped off and re-created by the AR code.
-      original = @transaction || @transaction_manager.current_transaction
-      transaction = original.dup
-      transaction.instance_variable_set(:@records, transaction.records.dup) # deep clone of records array
-      original.records.clear                                                # so that this clear doesn't clear out both copies
-      transaction.commit_records
-    end
-  end
-end
-
-if ActiveRecord::VERSION::MAJOR >= 4
-  # disable parts of the sync code that starts looping
-  ActiveRecord::Base.class_eval do
-    alias_method :sync_with_transaction_state_with_state, :sync_with_transaction_state
-    def sync_with_transaction_state
-      @reflects_state ||= []
-      @reflects_state[0] = true
-      sync_with_transaction_state_with_state
     end
   end
 end

--- a/lib/test_after_commit/database_statements.rb
+++ b/lib/test_after_commit/database_statements.rb
@@ -1,0 +1,45 @@
+module TestAfterCommit::DatabaseStatements
+  def transaction(*args)
+    @test_open_transactions ||= 0
+
+    super(*args) do
+      begin
+        @test_open_transactions += 1
+        if ActiveRecord::VERSION::MAJOR == 3
+          @_current_transaction_records.push([]) if @_current_transaction_records.empty?
+        end
+        result = yield
+      rescue Exception => e
+        rolled_back = true
+        raise e
+      ensure
+        begin
+          @test_open_transactions -= 1
+          if TestAfterCommit.enabled && @test_open_transactions == 0 && !rolled_back
+            test_commit_records
+          end
+        ensure
+          result
+        end
+      end
+    end
+  end
+
+  def test_commit_records
+    if ActiveRecord::VERSION::MAJOR == 3
+      commit_transaction_records
+    else
+      # To avoid an infinite loop, we need to copy the transaction locally, and clear out
+      # `records` on the copy that stays in the AR stack. Otherwise new
+      # transactions inside a commit callback will cause an infinite loop.
+      #
+      # This is because we're re-using the transaction on the stack, before
+      # it's been popped off and re-created by the AR code.
+      original = @transaction || @transaction_manager.current_transaction
+      transaction = original.dup
+      transaction.instance_variable_set(:@records, transaction.records.dup) # deep clone of records array
+      original.records.clear                                                # so that this clear doesn't clear out both copies
+      transaction.commit_records
+    end
+  end
+end

--- a/lib/test_after_commit/database_statements.rb
+++ b/lib/test_after_commit/database_statements.rb
@@ -9,9 +9,9 @@ module TestAfterCommit::DatabaseStatements
           @_current_transaction_records.push([]) if @_current_transaction_records.empty?
         end
         result = yield
-      rescue Exception => e
+      rescue Exception
         rolled_back = true
-        raise e
+        raise
       ensure
         begin
           @test_open_transactions -= 1

--- a/lib/test_after_commit/database_statements.rb
+++ b/lib/test_after_commit/database_statements.rb
@@ -1,8 +1,8 @@
 module TestAfterCommit::DatabaseStatements
-  def transaction(*args)
+  def transaction(*)
     @test_open_transactions ||= 0
 
-    super(*args) do
+    super do
       begin
         @test_open_transactions += 1
         if ActiveRecord::VERSION::MAJOR == 3

--- a/lib/test_after_commit/with_transaction_state.rb
+++ b/lib/test_after_commit/with_transaction_state.rb
@@ -7,6 +7,6 @@ module TestAfterCommit
       super
     end
 
-    ActiveRecord::Base.include(self)
+    ActiveRecord::Base.prepend(self)
   end
 end

--- a/lib/test_after_commit/with_transaction_state.rb
+++ b/lib/test_after_commit/with_transaction_state.rb
@@ -1,0 +1,12 @@
+# disable parts of the sync code that starts looping
+module TestAfterCommit
+  module WithTransactionState
+    def sync_with_transaction_state
+      @reflects_state ||= []
+      @reflects_state[0] = true
+      super
+    end
+
+    ActiveRecord::Base.__send__(:include, self)
+  end
+end

--- a/lib/test_after_commit/with_transaction_state.rb
+++ b/lib/test_after_commit/with_transaction_state.rb
@@ -7,6 +7,6 @@ module TestAfterCommit
       super
     end
 
-    ActiveRecord::Base.__send__(:include, self)
+    ActiveRecord::Base.include(self)
   end
 end

--- a/test_after_commit.gemspec
+++ b/test_after_commit.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new name, TestAfterCommit::VERSION do |s|
   s.files = `git ls-files lib Readme.md MIT-LICENSE`.split("\n")
   s.license = 'MIT'
 
+  s.required_ruby_version = '>= 2.0.0'
   s.add_runtime_dependency "activerecord", ">= 3.2"
 
   s.add_development_dependency "wwtd"


### PR DESCRIPTION
`alias_method_chain` is deprecated, replaced by `Module.prepend`.
Only thing I am unsure of is legacy support.