### PR TITLE
Always clear @_current_transaction_records in AR 3

### DIFF
--- a/lib/test_after_commit/database_statements.rb
+++ b/lib/test_after_commit/database_statements.rb
@@ -18,6 +18,9 @@ module TestAfterCommit::DatabaseStatements
           if TestAfterCommit.enabled && @test_open_transactions == 0 && !rolled_back
             test_commit_records
           end
+          if ActiveRecord::VERSION::MAJOR == 3 && @test_open_transactions == 0 && !rolled_back
+            @_current_transaction_records.clear
+          end
         ensure
           result
         end

--- a/lib/test_after_commit/database_statements.rb
+++ b/lib/test_after_commit/database_statements.rb
@@ -15,11 +15,12 @@ module TestAfterCommit::DatabaseStatements
       ensure
         begin
           @test_open_transactions -= 1
-          if TestAfterCommit.enabled && @test_open_transactions == 0 && !rolled_back
-            test_commit_records
-          end
-          if ActiveRecord::VERSION::MAJOR == 3 && @test_open_transactions == 0 && !rolled_back
-            @_current_transaction_records.clear
+          if @test_open_transactions == 0 && !rolled_back
+            if TestAfterCommit.enabled
+              test_commit_records
+            elsif ActiveRecord::VERSION::MAJOR == 3
+              @_current_transaction_records.clear
+            end
           end
         ensure
           result

--- a/spec/test_after_commit_spec.rb
+++ b/spec/test_after_commit_spec.rb
@@ -226,10 +226,10 @@ end
 
 if rails3? && !ENV["REAL"]
   describe TestAfterCommit, "with mixed TAC enabled specs" do
-    before {
+    before do
       TestAfterCommit.enabled = false
       Car.called.clear
-    }
+    end
 
     context "and a test with TAC disabled" do
       it "creates a record" do

--- a/spec/test_after_commit_spec.rb
+++ b/spec/test_after_commit_spec.rb
@@ -223,3 +223,36 @@ describe TestAfterCommit do
     end
   end
 end
+
+if rails3? && !ENV["REAL"]
+  describe TestAfterCommit, "with mixed TAC enabled specs" do
+    before {
+      TestAfterCommit.enabled = false
+      Car.called.clear
+    }
+
+    context "and a test with TAC disabled" do
+      it "creates a record" do
+        Car.new.save!
+        Car.called.should == []
+      end
+
+      it "verifies that records are empty before each test 1" do
+        connection.instance_variable_get(:@_current_transaction_records).should be_empty
+      end
+    end
+
+    context "and a test with TAC enabled" do
+      before { TestAfterCommit.enabled = true }
+
+      it "creates a record and fires commit callbacks" do
+        Car.new.save!
+        Car.called.should == [:create, :always]
+      end
+
+      it "verifies that records are empty before each test 2" do
+        connection.instance_variable_get(:@_current_transaction_records).should be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This isn't necessarily a TAC bug, but rather an area where I think TAC could help. When using TAC in a project but setting it to be disabled by default, transaction records accumulate across tests due to the way that AR use_transactional_fixtures operates. Then when you enable TAC for an individual
test, those excess records from other tests may have commit hooks fired for them, causing unintended side effects.

This fix clears the @_current_transaction_records array after every test transaction regardless of whether TAC is enabled.