### PR TITLE
Fix undefined method `records' error.

### DIFF
--- a/lib/test_after_commit/database_statements.rb
+++ b/lib/test_after_commit/database_statements.rb
@@ -1,6 +1,7 @@
 module TestAfterCommit::DatabaseStatements
   def transaction(*)
     @test_open_transactions ||= 0
+    skip_emulation = ActiveRecord::Base.connection.open_transactions.zero?
     run_callbacks = false
     result = nil
     rolled_back = false
@@ -17,7 +18,7 @@ module TestAfterCommit::DatabaseStatements
         raise
       ensure
         @test_open_transactions -= 1
-        if @test_open_transactions == 0 && !rolled_back
+        if @test_open_transactions == 0 && !rolled_back && !skip_emulation
           if TestAfterCommit.enabled
             run_callbacks = true
           elsif ActiveRecord::VERSION::MAJOR == 3

--- a/lib/test_after_commit/database_statements.rb
+++ b/lib/test_after_commit/database_statements.rb
@@ -1,9 +1,9 @@
 module TestAfterCommit::DatabaseStatements
   def transaction(*)
     @test_open_transactions ||= 0
-    skip_emulation = ActiveRecord::Base.connection.open_transactions.zero?
     run_callbacks = false
     result = nil
+    rolled_back = false
 
     super do
       begin
@@ -17,7 +17,7 @@ module TestAfterCommit::DatabaseStatements
         raise
       ensure
         @test_open_transactions -= 1
-        if @test_open_transactions == 0 && !rolled_back && !skip_emulation
+        if @test_open_transactions == 0 && !rolled_back
           if TestAfterCommit.enabled
             run_callbacks = true
           elsif ActiveRecord::VERSION::MAJOR == 3
@@ -42,6 +42,9 @@ module TestAfterCommit::DatabaseStatements
       # This is because we're re-using the transaction on the stack, before
       # it's been popped off and re-created by the AR code.
       original = @transaction || @transaction_manager.current_transaction
+
+      return unless original.respond_to?(:records)
+
       transaction = original.dup
       transaction.instance_variable_set(:@records, transaction.records.dup) # deep clone of records array
       original.records.clear                                                # so that this clear doesn't clear out both copies


### PR DESCRIPTION
Checking if the transaction responds to `:records' method.

Also added `rolled_back` variable initialization to safeguards against possible error.
