### PR TITLE
Frameworks are not all Rails

### DIFF
--- a/lib/test_after_commit.rb
+++ b/lib/test_after_commit.rb
@@ -1,9 +1,5 @@
 require 'test_after_commit/version'
 
-if ActiveRecord::VERSION::MAJOR >= 5
-  raise 'after_commit testing is baked into rails 5, you no longer need test_after_commit gem'
-end
-
 if ActiveRecord::VERSION::MAJOR >= 4
   require 'test_after_commit/with_transaction_state'
   ActiveRecord::Base.send(:prepend, TestAfterCommit::WithTransactionState)

--- a/test_after_commit.gemspec
+++ b/test_after_commit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new name, TestAfterCommit::VERSION do |s|
   s.license = 'MIT'
 
   s.required_ruby_version = '>= 2.0.0'
-  s.add_runtime_dependency "activerecord", [">= 3.2", "< 5.0"]
+  s.add_runtime_dependency "activerecord", ">= 3.2"
   
   s.add_development_dependency "wwtd"
   s.add_development_dependency "bump"


### PR DESCRIPTION
When using this with active record within a framework like Grape, it is still useful.

From my commit messages:

> Non-Rails apps, like Grape, Sinatra, etc, which may use ActiveRecord, still have need of the ability to test `after_commit`.

> Grape, Sinatra, and other Ruby frameworks, may use ActiveRecord, but be unable to utilize Rails' built-in `use_transactional_tests`, due to it not being part of ActiveRecord, but instead part of Rails proper.